### PR TITLE
Fix pvc length

### DIFF
--- a/charts/app-text-embeddings-inference/templates/_helpers.tpl
+++ b/charts/app-text-embeddings-inference/templates/_helpers.tpl
@@ -23,6 +23,10 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "app.hfcachename" -}}
+{{- printf "%s-cache" (include "app.fullname" . | trunc 57 | trimSuffix "-") }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/app-text-embeddings-inference/templates/deployment.yaml
+++ b/charts/app-text-embeddings-inference/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
       {{- if .Values.HFCacheVolume.enabled }}
         - name: huggingface-cache
           persistentVolumeClaim:
-            claimName: {{ include "app.fullname" . }}-cache
+            claimName: {{ include "app.hfcachename" . }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/app-text-embeddings-inference/templates/pvc.yaml
+++ b/charts/app-text-embeddings-inference/templates/pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "app.fullname" . }}-cache
+  name: {{ include "app.hfcachename" . }}
   labels:
     {{- include "app.labels" $ | nindent 4 }}
   annotations:


### PR DESCRIPTION
Results in a PVC name like this:

```
---
# Source: app-text-embedding-inference/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: apolo-jordy-demo-text-embeddings-inference-eb962f59-app-t-cache
  labels:
    application: text-embeddings-inference
    helm.sh/chart: app-text-embedding-inference-0.1.0
    app.kubernetes.io/name: app-text-embedding-inference
    app.kubernetes.io/instance: apolo-jordy-demo-text-embeddings-inference-eb962f59
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/resource-policy": keep
spec:
  accessModes:
    - ReadWriteOnce
```
